### PR TITLE
Customisation metadata instead of tags

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -87,6 +87,24 @@ prose:
             element: text
             label: "Indicator available"
             scope: national
+      - name: "customisation"
+        field:
+            element: select
+            label: "Customisation"
+            options:
+              - name: '1'
+                value: 'meta.customisation-1'
+                translation_key: 'meta.customisation-1'
+              - name: '2'
+                value: 'meta.customisation-2'
+                translation_key: 'meta.customisation-2'
+              - name: '3'
+                value: 'meta.customisation-3'
+                translation_key: 'meta.customisation-3'
+              - name: '4'
+                value: 'meta.customisation-4'
+                translation_key: 'meta.customisation-4'
+            scope: data
       - name: "national_indicator_description"
         field:
             element: text

--- a/_prose.yml
+++ b/_prose.yml
@@ -82,11 +82,6 @@ prose:
             element: text
             label: "Classification"
             scope: national
-      - name: "national_indicator_available"
-        field:
-            element: text
-            label: "Indicator available"
-            scope: national
       - name: "customisation"
         field:
             element: select
@@ -104,7 +99,12 @@ prose:
               - name: '4'
                 value: 'meta.customisation-4'
                 translation_key: 'meta.customisation-4'
-            scope: data
+            scope: national
+      - name: "national_indicator_available"
+        field:
+            element: text
+            label: "Indicator available"
+            scope: national
       - name: "national_indicator_description"
         field:
             element: text

--- a/meta/1-1-1.md
+++ b/meta/1-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-01-01a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)
@@ -23,8 +23,8 @@ source_compilation_1: Комитет по статистике (Управлен
 source_data_1: Обследование домохозяйств по оценке уровня жизни
 source_implementation_1: Министерство труда и социальной защиты населения Республики
   Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, eradicate extreme poverty for all people everywhere, currently measured
   as people living on less than $1.25 a day
 target_id: '1.1'

--- a/meta/1-2-1.md
+++ b/meta/1-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-01-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 98.2
@@ -28,8 +28,8 @@ source_compilation_1: Комитет по статистике  (Управле�
 source_data_1: Обследование домохозяйств по оценке уровня жизни
 source_implementation_1: Министерство труда и социальной защиты населения Республики
   Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, reduce at least by half the proportion of men, women and children
   of all ages living in poverty in all its dimensions according to national definitions.
 target_id: '1.2'

--- a/meta/1-2-2.md
+++ b/meta/1-2-2.md
@@ -1,9 +1,8 @@
 ---
 availability: 2
-classification: "3 уровень \nОтложить в связи с отсутствием методологии на глобальном\
-  \ уровне"
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-01-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 894

--- a/meta/1-3-1.md
+++ b/meta/1-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-03-01a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)

--- a/meta/1-4-1.md
+++ b/meta/1-4-1.md
@@ -1,9 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень. Методология на глобальном уровне есть. Данные будут рассчитаны
-  по итогам переписи населения в 2021 г.
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)

--- a/meta/1-4-2.md
+++ b/meta/1-4-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: человек
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: NA
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
@@ -25,8 +25,8 @@ source_data_1: Ведомственные данные Республики Ка
   органы ведомственные данные
 source_implementation_1: Комитет по управлению земельными ресурсами Министерства сельского
   хозяйства Республики Казахстан
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2030, ensure that all men and women, in particular the poor and the vulnerable,
   have equal rights to economic resources, as well as access to basic services, ownership
   and control over land and other forms of property, inheritance, natural resources,

--- a/meta/1-5-1.md
+++ b/meta/1-5-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 224
@@ -22,8 +22,8 @@ source_active_1: true
 source_compilation_1: Комитет по чрезвычайным ситуациям МВД РК
 source_data_1: Сводные оперативные данные
 source_implementation_1: Комитет по чрезвычайным ситуациям МВД РК
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, build the resilience of the poor and those in vulnerable situations
   and reduce their exposure and vulnerability to climate-related extreme events and
   other economic, social and environmental shocks and disasters

--- a/meta/1-5-2.md
+++ b/meta/1-5-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)

--- a/meta/1-5-3.md
+++ b/meta/1-5-3.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)

--- a/meta/1-5-4.md
+++ b/meta/1-5-4.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
 graph_title: meta.name-1-5-4

--- a/meta/1-a-1.md
+++ b/meta/1-a-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)

--- a/meta/1-a-2.md
+++ b/meta/1-a-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: TIER III - NO WORK PLAN

--- a/meta/1-a-3.md
+++ b/meta/1-a-3.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
 graph_title: meta.name-1-a-3

--- a/meta/1-b-1.md
+++ b/meta/1-b-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-1.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 894kB)

--- a/meta/10-1-1.md
+++ b/meta/10-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 221

--- a/meta/10-2-1.md
+++ b/meta/10-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/10-3-1.md
+++ b/meta/10-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: количество
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/10-4-1.md
+++ b/meta/10-4-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 190

--- a/meta/10-5-1.md
+++ b/meta/10-5-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 4
+customisation: meta.customisation-4
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
@@ -23,8 +23,8 @@ source_compilation_1: Министерство финансов Республи
 source_data_1: null
 source_implementation_1: Министерство финансов Республики Казахстан,  Министерство
   национальной экономики Республики Казахстан, Национальный банк Республики Казахстан
-tags:
-- meta.customisation-4
+tags: []
+
 target: Improve the regulation and monitoring of global financial markets and institutions
   and strengthen the implementation of such regulations
 target_id: '10.5'

--- a/meta/10-6-1.md
+++ b/meta/10-6-1.md
@@ -1,8 +1,8 @@
 ---
 availability: null
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 201

--- a/meta/10-7-1.md
+++ b/meta/10-7-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)

--- a/meta/10-7-2.md
+++ b/meta/10-7-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)

--- a/meta/10-a-1.md
+++ b/meta/10-a-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 564kB)
@@ -23,8 +23,8 @@ source_compilation_1: Министерство национальной экон
 source_data_1: Сайт Евразийской экономической комиссии
 source_implementation_1: Министерство национальной экономики Республики Казахстан
   (Департамент развития внешнеторговой деятельности)
-tags:
-- meta.customisation-2
+tags: []
+
 target: Implement the principle of special and differential treatment for developing
   countries, in particular least developed countries, in accordance with World Trade
   Organization agreements

--- a/meta/11-1-1.md
+++ b/meta/11-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: человек
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 93.1
@@ -25,8 +25,8 @@ source_compilation_1: Комитет по статистике  (Управле�
 source_data_1: Информационная система "Статистический регистр жилищного фонда"
 source_implementation_1: Министерство по инвестициям и развитию Республики Казахстан,
   Местные исполнительные органы
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, ensure access for all to adequate, safe and affordable housing and
   basic services and upgrade slums
 target_id: '11.1'

--- a/meta/11-2-1.md
+++ b/meta/11-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)

--- a/meta/11-3-1.md
+++ b/meta/11-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: кв.м.
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)

--- a/meta/11-3-2.md
+++ b/meta/11-3-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)

--- a/meta/11-4-1.md
+++ b/meta/11-4-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: Министерство культуры и спорта Республики Казахстан
 source_data_1: null
 source_implementation_1: Министерство культуры и спорта Республики Казахстан
-tags:
-- meta.customisation-3
+tags: []
+
 target: Strengthen efforts to protect and safeguard the world’s cultural and natural
   heritage
 target_id: '11.4'

--- a/meta/11-5-1.md
+++ b/meta/11-5-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 224
@@ -24,8 +24,8 @@ source_compilation_1: Комитет по чрезвычайным ситуац�
 source_data_1: Сводные оперативные данные
 source_implementation_1: Комитет по чрезвычайным ситуациям Министерство внутренних
   дел Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, significantly reduce the number of deaths and the number of people
   affected and substantially decrease the direct economic losses relative to global
   gross domestic product caused by disasters, including water-related disasters, with

--- a/meta/11-5-2.md
+++ b/meta/11-5-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)

--- a/meta/11-6-1.md
+++ b/meta/11-6-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МНЭ РК, МИО
 source_data_1: null
 source_implementation_1: МЭ РК
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2030, reduce the adverse per capita environmental impact of cities, including
   by paying special attention to air quality and municipal and other waste management
 target_id: '11.6'

--- a/meta/11-6-2.md
+++ b/meta/11-6-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: мг/метр куб
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-11-06-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211

--- a/meta/11-7-1.md
+++ b/meta/11-7-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)

--- a/meta/11-7-2.md
+++ b/meta/11-7-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/11-a-1.md
+++ b/meta/11-a-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)

--- a/meta/11-b-1.md
+++ b/meta/11-b-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)

--- a/meta/11-b-2.md
+++ b/meta/11-b-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-11.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 2066kB)

--- a/meta/11-c-1.md
+++ b/meta/11-c-1.md
@@ -1,8 +1,8 @@
 ---
 availability: null
-classification: 4 уровень
+classification: 4
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/?Text=&Goal=11&Target= '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/12-1-1.md
+++ b/meta/12-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)

--- a/meta/12-2-1.md
+++ b/meta/12-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/12-2-2.md
+++ b/meta/12-2-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 783

--- a/meta/12-3-1.md
+++ b/meta/12-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)

--- a/meta/12-4-1.md
+++ b/meta/12-4-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-12-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)

--- a/meta/12-4-2.md
+++ b/meta/12-4-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: млн.тонн/год
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МЭ РК (ДУО), МИО
 source_data_1: null
 source_implementation_1: МЭ РК (ДУО), МИО
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2020, achieve the environmentally sound management of chemicals and all
   wastes throughout their life cycle, in accordance with agreed international frameworks,
   and significantly reduce their release to air, water and soil in order to minimize

--- a/meta/12-5-1.md
+++ b/meta/12-5-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МЭ (ДУО), МИО
 source_data_1: null
 source_implementation_1: МЭ, МИО
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2030, substantially reduce waste generation through prevention, reduction,
   recycling and reuse
 target_id: '12.5'

--- a/meta/12-6-1.md
+++ b/meta/12-6-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)

--- a/meta/12-7-1.md
+++ b/meta/12-7-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)

--- a/meta/12-8-1.md
+++ b/meta/12-8-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)

--- a/meta/12-a-1.md
+++ b/meta/12-a-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)

--- a/meta/12-b-1.md
+++ b/meta/12-b-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)

--- a/meta/12-c-1.md
+++ b/meta/12-c-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-12.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 782kB)

--- a/meta/13-1-1.md
+++ b/meta/13-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-13-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 224
@@ -24,8 +24,8 @@ source_compilation_1: Комитет по чрезвычайным ситуац�
 source_data_1: Сводные оперативные данные
 source_implementation_1: Комитет по чрезвычайным ситуациям Министерство внутренних
   дел Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: Strengthen resilience and adaptive capacity to climate-related hazards and
   natural disasters in all countries
 target_id: '13.1'

--- a/meta/13-1-2.md
+++ b/meta/13-1-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-01-05-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)

--- a/meta/13-1-3.md
+++ b/meta/13-1-3.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
 graph_title: meta.name-13-1-3
@@ -22,8 +22,8 @@ source_compilation_1: "Местные исполнительные органы,
 source_data_1: В ПРТ МИО отражены меры по защите населения и территорий от  стихийных
   бедствий природного и техногенного характера
 source_implementation_1: Местные исполнительные органы
-tags:
-- meta.customisation-3
+tags: []
+
 target: Strengthen resilience and adaptive capacity to climate-related hazards and
   natural disasters in all countries
 target_id: '13.1'

--- a/meta/13-2-1.md
+++ b/meta/13-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: null
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)

--- a/meta/13-3-1.md
+++ b/meta/13-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МОН РК, МТСЗН, МВД РК (КЧС)
 source_data_1: null
 source_implementation_1: МОН РК, МТСЗН, МВД РК (КЧС)
-tags:
-- meta.customisation-3
+tags: []
+
 target: Improve education, awareness-raising and human and institutional capacity
   on climate change mitigation, adaptation, impact reduction and early warning
 target_id: '13.3'

--- a/meta/13-3-2.md
+++ b/meta/13-3-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)

--- a/meta/13-b-1.md
+++ b/meta/13-b-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-13.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 759kB)

--- a/meta/14-1-1.md
+++ b/meta/14-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)

--- a/meta/14-2-1.md
+++ b/meta/14-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288

--- a/meta/14-3-1.md
+++ b/meta/14-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: единиц
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
@@ -22,8 +22,8 @@ source_compilation_1: Министерство энергетики Респуб
 source_data_1: null
 source_implementation_1: "Министерство энергетики Республики Казахстан, \nКомитет\
   \ по водным ресурсам Министерство сельского хозяйства Республики Казахстан"
-tags:
-- meta.customisation-2
+tags: []
+
 target: Minimize and address the impacts of ocean acidification, including through
   enhanced scientific cooperation at all levels
 target_id: '14.3'

--- a/meta/14-4-1.md
+++ b/meta/14-4-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: количество
-customisation: 4
+customisation: meta.customisation-4
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-14-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 370
@@ -30,8 +30,8 @@ source_compilation_1: Комитет лесного хозяйства и жив
 source_data_1: null
 source_implementation_1: Комитет лесного хозяйства и животного мира Министерства сельского
   хозяйства (Управление воспроизводства рыбных ресурсов и аквакультуры)
-tags:
-- meta.customisation-4
+tags: []
+
 target: By 2020, effectively regulate harvesting and end overfishing, illegal, unreported
   and unregulated fishing and destructive fishing practices and implement science-based
   management plans, in order to restore fish stocks in the shortest time feasible,

--- a/meta/14-5-1.md
+++ b/meta/14-5-1.md
@@ -2,7 +2,7 @@
 availability: null
 classification: 1
 computation_units: null
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-14-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 293
@@ -26,8 +26,8 @@ source_active_1: true
 source_compilation_1: МСХ  (КЛХЖМ)
 source_data_1: null
 source_implementation_1: МСХ
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2020, conserve at least 10 per cent of coastal and marine areas, consistent
   with national and international law and based on the best available scientific information
 target_id: '14.5'

--- a/meta/14-6-1.md
+++ b/meta/14-6-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)

--- a/meta/14-7-1.md
+++ b/meta/14-7-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)
@@ -24,8 +24,8 @@ source_compilation_1: Комитет по статистике  Министер
 source_data_1: Данные отраслевой статистики (1-рыба) и ВВП в текущих ценах
 source_implementation_1: Министерство сельского хозяйства Республики Казахстан (КХЛЖМ
   Управление воспроизводства рыбных ресурсов и аквакультуры)
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2030, increase the economic benefits to small island developing States
   and least developed countries from the sustainable use of marine resources, including
   through sustainable management of fisheries, aquaculture and tourism

--- a/meta/14-a-1.md
+++ b/meta/14-a-1.md
@@ -1,8 +1,8 @@
 ---
 availability: null
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)

--- a/meta/14-b-1.md
+++ b/meta/14-b-1.md
@@ -1,8 +1,8 @@
 ---
 availability: null
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)

--- a/meta/14-c-1.md
+++ b/meta/14-c-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-14.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 288kB)

--- a/meta/15-1-1.md
+++ b/meta/15-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 379

--- a/meta/15-1-2.md
+++ b/meta/15-1-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-01-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
@@ -22,8 +22,8 @@ source_compilation_1: Комитет лесного хозяйства и жив
   хозяйства Республики Казахстан (Управление леса и ООПТ)
 source_data_1: null
 source_implementation_1: Министерство сельского хозяйства Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2020, ensure the conservation, restoration and sustainable use of terrestrial
   and inland freshwater ecosystems and their services, in particular forests, wetlands,
   mountains and drylands, in line with obligations under international agreements

--- a/meta/15-2-1.md
+++ b/meta/15-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: тыс.гектар
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-15-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 756
@@ -23,8 +23,8 @@ source_compilation_1: Комитет лесного хозяйства и жив
   хозяйства Республики Казахстан (Управление леса и ООПТ)
 source_data_1: null
 source_implementation_1: Министерство сельского хозяйства Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2020, promote the implementation of sustainable management of all types
   of forests, halt deforestation, restore degraded forests and substantially increase
   afforestation and reforestation globally

--- a/meta/15-3-1.md
+++ b/meta/15-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: тыс.гектар
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МСХ (КУЗР)
 source_data_1: null
 source_implementation_1: МСХ
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2030, combat desertification, restore degraded land and soil, including
   land affected by desertification, drought and floods, and strive to achieve a land
   degradation-neutral world

--- a/meta/15-4-1.md
+++ b/meta/15-4-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)

--- a/meta/15-4-2.md
+++ b/meta/15-4-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: тыс.гектар
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 384
@@ -23,8 +23,8 @@ source_compilation_1: Комитет лесного хозяйства и жив
   хозяйства Республики Казахстан (Управление леса и ООПТ)
 source_data_1: null
 source_implementation_1: Министерство сельского хозяйства Республики Казахстан
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2030, ensure the conservation of mountain ecosystems, including their biodiversity,
   in order to enhance their capacity to provide benefits that are essential for sustainable
   development

--- a/meta/15-5-1.md
+++ b/meta/15-5-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 440
   KB)
@@ -22,8 +22,8 @@ source_compilation_1: Комитет лесного хозяйства и жив
   хозяйства Республики Казахстан
 source_data_1: null
 source_implementation_1: Министерство сельского хозяйства Республики Казахстан
-tags:
-- meta.customisation-3
+tags: []
+
 target: Take urgent and significant action to reduce the degradation of natural habitats,
   halt the loss of biodiversity and, by 2020, protect and prevent the extinction of
   threatened species

--- a/meta/15-6-1.md
+++ b/meta/15-6-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-15-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)

--- a/meta/15-7-1.md
+++ b/meta/15-7-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
@@ -22,8 +22,8 @@ source_active_1: true
 source_compilation_1: КЛХЖМ МСХ РК, МОН РК
 source_data_1: null
 source_implementation_1: МСХ РК, МОН РК
-tags:
-- meta.customisation-3
+tags: []
+
 target: Take urgent action to end poaching and trafficking of protected species of
   flora and fauna and address both demand and supply of illegal wildlife products
 target_id: '15.7'

--- a/meta/15-8-1.md
+++ b/meta/15-8-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)

--- a/meta/15-9-1.md
+++ b/meta/15-9-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 456kB)

--- a/meta/15-a-1.md
+++ b/meta/15-a-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-15.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/15-c-1.md
+++ b/meta/15-c-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: количество
-customisation: 4
+customisation: meta.customisation-4
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
   KB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МСХ РК КЛХЖМ, МОН РК
 source_data_1: null
 source_implementation_1: МСХ РК, МОН РК
-tags:
-- meta.customisation-4
+tags: []
+
 target: Enhance global support for efforts to combat poaching and trafficking of protected
   species, including by increasing the capacity of local communities to pursue sustainable
   livelihood opportunities

--- a/meta/16-1-1.md
+++ b/meta/16-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: количество
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-16-01-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 222

--- a/meta/16-1-2.md
+++ b/meta/16-1-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 1.3

--- a/meta/16-1-3.md
+++ b/meta/16-1-3.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-16-01-03.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 217

--- a/meta/16-1-4.md
+++ b/meta/16-1-4.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 213
@@ -26,8 +26,8 @@ source_data_1: Выборочное обследование "Уровень д�
   органам"
 source_implementation_1: Генеральная прокуратура Республики Казахстан, Министерство
   внутренних дел Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: 16.1 Significantly reduce all forms of violence and related death rates everywhere
 target_id: '16.1'
 un_custodian_agency: United Nations Office on Drugs and Crime (UNODC)

--- a/meta/16-10-1.md
+++ b/meta/16-10-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-10-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)

--- a/meta/16-10-2.md
+++ b/meta/16-10-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-10-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: Министерство информации и коммуникаций Республики Казахстан
 source_data_1: null
 source_implementation_1: Министерство информации и коммуникаций Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: Ensure public access to information and protect fundamental freedoms, in accordance
   with national legislation and international agreements
 target_id: '16.10'

--- a/meta/16-2-1.md
+++ b/meta/16-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
@@ -23,8 +23,8 @@ source_compilation_1: Комитет по статистике Министер�
 source_data_1: Выборочное обследование MICS
 source_implementation_1: Генеральная прокуратура Республики Казахстан, Министерство
   внутренних дел Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: End abuse, exploitation, trafficking and all forms of violence against and
   torture of children
 target_id: '16.2'

--- a/meta/16-2-2.md
+++ b/meta/16-2-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
@@ -24,8 +24,8 @@ source_compilation_1: "МДВ РК, Комитет по правовой ста�
 source_data_1: Статистические данные формы 1-М "О зарегистрированных уголовных правонарушениях"
 source_implementation_1: Министерство внутренних дел Республики Казахстан, Генеральная
   прокуратура Республики Казахстан,
-tags:
-- meta.customisation-2
+tags: []
+
 target: End abuse, exploitation, trafficking and all forms of violence against and
   torture of children
 target_id: '16.2'

--- a/meta/16-2-3.md
+++ b/meta/16-2-3.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-02-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 208
@@ -27,8 +27,8 @@ source_active_1: true
 source_compilation_1: КС МНЭ РК (УСЦУР)
 source_data_1: null
 source_implementation_1: МВД РК, МЗ РК, МОН РК, ГП РК, МТСЗН РК
-tags:
-- meta.customisation-2
+tags: []
+
 target: End abuse, exploitation, trafficking and all forms of violence against and
   torture of children
 target_id: '16.2'

--- a/meta/16-3-1.md
+++ b/meta/16-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)

--- a/meta/16-3-2.md
+++ b/meta/16-3-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: человек
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 209
@@ -23,8 +23,8 @@ source_compilation_1: КПССУ ГП РК
 source_data_1: null
 source_implementation_1: ВС РК, ГП РК, АГДСПК РК, МВД РК (Все провоохранительные и
   специальные органы)
-tags:
-- meta.customisation-2
+tags: []
+
 target: Promote the rule of law at the national and international levels and ensure
   equal access to justice for all
 target_id: '16.3'

--- a/meta/16-4-1.md
+++ b/meta/16-4-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)

--- a/meta/16-4-2.md
+++ b/meta/16-4-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
@@ -23,8 +23,8 @@ source_compilation_1: Комитет по правовой статистике 
 source_data_1: null
 source_implementation_1: Министерство внутренних дел Республики Казахстан, Генеральная
   прокуратура Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, significantly reduce illicit financial and arms flows, strengthen
   the recovery and return of stolen assets and combat all forms of organized crime
 target_id: '16.4'

--- a/meta/16-5-1.md
+++ b/meta/16-5-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)

--- a/meta/16-5-2.md
+++ b/meta/16-5-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)

--- a/meta/16-6-1.md
+++ b/meta/16-6-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процентах
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
@@ -23,8 +23,8 @@ source_compilation_1: Министерство финансов Республи
 source_data_1: null
 source_implementation_1: Министерство финансов Республики Казахстан (Департамент отчетности
   и статистики государственных финансов )
-tags:
-- meta.customisation-2
+tags: []
+
 target: Develop effective, accountable and transparent institutions at all levels
 target_id: '16.6'
 un_custodian_agency: World Bank

--- a/meta/16-6-2.md
+++ b/meta/16-6-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)

--- a/meta/16-7-1.md
+++ b/meta/16-7-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-16.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/16-8-1.md
+++ b/meta/16-8-1.md
@@ -1,8 +1,8 @@
 ---
 availability: null
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-10-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МИД РК
 source_data_1: null
 source_implementation_1: МИД РК
-tags:
-- meta.customisation-2
+tags: []
+
 target: Broaden and strengthen the participation of developing countries in the institutions
   of global governance
 target_id: '16.8'

--- a/meta/16-9-1.md
+++ b/meta/16-9-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-09-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)
@@ -22,8 +22,8 @@ source_compilation_1: Комитет по статистике Министер�
   Казахстан (УСДС)
 source_data_1: Выборочное обледование MICS
 source_implementation_1: МЮ РК, МВД РК, МИД РК
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, provide legal identity for all, including birth registration
 target_id: '16.9'
 un_custodian_agency: United Nations Statistics Division (UNSD), United Nations International

--- a/meta/16-a-1.md
+++ b/meta/16-a-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-16-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 1361kB)

--- a/meta/16-b-1.md
+++ b/meta/16-b-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: количество
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-10.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
@@ -26,8 +26,8 @@ source_data_1: null
 source_implementation_1: "Наццентр по правам человека, Министерство образования и\
   \ науки Республики Казахстан, \nМинистерство труда и социальной защиты населения\
   \ Республики Казахстан"
-tags:
-- meta.customisation-2
+tags: []
+
 target: Promote and enforce non-discriminatory laws and policies for sustainable development
 target_id: 16.b
 un_custodian_agency: Office of the United Nations High Commissioner for Human Rights

--- a/meta/17-1-1.md
+++ b/meta/17-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 469

--- a/meta/17-1-2.md
+++ b/meta/17-1-2.md
@@ -1,8 +1,8 @@
 ---
 availability: null
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 469

--- a/meta/17-10-1.md
+++ b/meta/17-10-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 4
+customisation: meta.customisation-4
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-10-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
@@ -23,8 +23,8 @@ source_compilation_1: Министерства национальной экон
 source_data_1: Единный таможенный тариф ЕАЭС
 source_implementation_1: Министерства национальной экономики Республики Казахстан
   , Министерство иностранных дел Республики Казахстан
-tags:
-- meta.customisation-4
+tags: []
+
 target: Promote a universal, rules-based, open, non‑discriminatory and equitable multilateral
   trading system under the World Trade Organization, including through the conclusion
   of negotiations under its Doha Development Agenda

--- a/meta/17-11-1.md
+++ b/meta/17-11-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-11-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-12-1.md
+++ b/meta/17-12-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-12-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-13-1.md
+++ b/meta/17-13-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-14-1.md
+++ b/meta/17-14-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-15-1.md
+++ b/meta/17-15-1.md
@@ -1,8 +1,8 @@
 ---
 availability: null
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-15-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-16-1.md
+++ b/meta/17-16-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-16-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-17-1.md
+++ b/meta/17-17-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: Министерство национальной экономики РК
 source_data_1: null
 source_implementation_1: Министерство национальной экономики РК
-tags:
-- meta.customisation-3
+tags: []
+
 target: Encourage and promote effective public, public-private and civil society partnerships,
   building on the experience and resourcing strategies of partnerships
 target_id: '17.17'

--- a/meta/17-18-1.md
+++ b/meta/17-18-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3-уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-18-2.md
+++ b/meta/17-18-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-18-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-18-3.md
+++ b/meta/17-18-3.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-18-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-19-1.md
+++ b/meta/17-19-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-19-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-19-2.md
+++ b/meta/17-19-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-19-02a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-2-1.md
+++ b/meta/17-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-3-1.md
+++ b/meta/17-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МИД РК, МНЭ РК
 source_data_1: null
 source_implementation_1: МИД РК
-tags:
-- meta.customisation-2
+tags: []
+
 target: Mobilize additional financial resources for developing countries from multiple
   sources
 target_id: '17.3'

--- a/meta/17-3-2.md
+++ b/meta/17-3-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
@@ -23,8 +23,8 @@ source_compilation_1: 'НБ РК, КС МНЭ РК
   (данные по ВВП)'
 source_data_1: null
 source_implementation_1: МТСЗН РК
-tags:
-- meta.customisation-2
+tags: []
+
 target: Mobilize additional financial resources for developing countries from multiple
   sources
 target_id: '17.3'

--- a/meta/17-4-1.md
+++ b/meta/17-4-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-17-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)
@@ -22,8 +22,8 @@ source_compilation_1: "Национальный банк \nРеспублики 
   \ Республики Казахстан"
 source_data_1: null
 source_implementation_1: Министерство финансов Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: Assist developing countries in attaining long-term debt sustainability through
   coordinated policies aimed at fostering debt financing, debt relief and debt restructuring,
   as appropriate, and address the external debt of highly indebted poor countries

--- a/meta/17-5-1.md
+++ b/meta/17-5-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-6-1.md
+++ b/meta/17-6-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-6-2.md
+++ b/meta/17-6-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: тыс.единиц
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-17-06-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211

--- a/meta/17-7-1.md
+++ b/meta/17-7-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-17.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 468kB)

--- a/meta/17-8-1.md
+++ b/meta/17-8-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-17-08-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 469

--- a/meta/17-9-1.md
+++ b/meta/17-9-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 4
+customisation: meta.customisation-4
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-17-09-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 209
@@ -25,8 +25,8 @@ source_active_1: true
 source_compilation_1: МИД РК
 source_data_1: МИД РК
 source_implementation_1: null
-tags:
-- meta.customisation-4
+tags: []
+
 target: Enhance international support for implementing effective and targeted capacity-building
   in developing countries to support national plans to implement all the Sustainable
   Development Goals, including through North-South, South-South and triangular cooperation

--- a/meta/2-1-1.md
+++ b/meta/2-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)

--- a/meta/2-1-2.md
+++ b/meta/2-1-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 426
   KB)

--- a/meta/2-2-1.md
+++ b/meta/2-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)

--- a/meta/2-2-2.md
+++ b/meta/2-2-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-02-02a.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)

--- a/meta/2-3-1.md
+++ b/meta/2-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: тыс.тенге
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-2.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
@@ -24,8 +24,8 @@ source_compilation_1: Комитет по статистике Министер�
 source_data_1: ВДС сельского, лесного и рыбного хозяйства в текущих ценах, численность
   населения
 source_implementation_1: Министерство сельского хозяйства Республики Казахстан
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2030, double the agricultural productivity and incomes of small-scale food
   producers, in particular women, indigenous peoples, family farmers, pastoralists
   and fishers, including through secure and equal access to land, other productive

--- a/meta/2-3-2.md
+++ b/meta/2-3-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: "3 уровень \nОтложить на более поздний срок"
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-2.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/2-4-1.md
+++ b/meta/2-4-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
   MB)
@@ -23,8 +23,8 @@ source_compilation_1: Министерство сельского хозяйст
 source_data_1: null
 source_implementation_1: Министерство сельского хозяйства Республики Казахстан (Департамент
   земледелия)
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2030, ensure sustainable food production systems and implement resilient
   agricultural practices that increase productivity and production, that help maintain
   ecosystems, that strengthen capacity for adaptation to climate change, extreme weather,

--- a/meta/2-5-1.md
+++ b/meta/2-5-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 334

--- a/meta/2-5-2.md
+++ b/meta/2-5-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 220
@@ -27,8 +27,8 @@ source_compilation_1: Комитет лесного хозяйства и жив
 source_data_1: null
 source_implementation_1: Комитет лесного хозяйства и животного мира Министерство сельского
   хозяйства Республики Казахстан
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2020, maintain the genetic diversity of seeds, cultivated plants and farmed
   and domesticated animals and their related wild species, including through soundly
   managed and diversified seed and plant banks at the national, regional and international

--- a/meta/2-a-1.md
+++ b/meta/2-a-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-02-0A-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 223

--- a/meta/2-a-2.md
+++ b/meta/2-a-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-02-0A-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210

--- a/meta/2-c-1.md
+++ b/meta/2-c-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-02-0C-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 232kB)

--- a/meta/3-1-1.md
+++ b/meta/3-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: на 100 тыс.родившихся живыми
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)

--- a/meta/3-1-2.md
+++ b/meta/3-1-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-01-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 374

--- a/meta/3-2-1.md
+++ b/meta/3-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: на 1000 родившихся
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 225

--- a/meta/3-2-2.md
+++ b/meta/3-2-2.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 1
 computation_units: на 1000 родившихся
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 225

--- a/meta/3-3-1.md
+++ b/meta/3-3-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 1
 computation_units: на 1000 неинфицированных
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 372

--- a/meta/3-3-2.md
+++ b/meta/3-3-2.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 1
 computation_units: на 100 000 человек
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 61

--- a/meta/3-3-3.md
+++ b/meta/3-3-3.md
@@ -2,7 +2,7 @@
 availability: 2
 classification: 4
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 431

--- a/meta/3-3-4.md
+++ b/meta/3-3-4.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: на 100 000 человек
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)

--- a/meta/3-3-5.md
+++ b/meta/3-3-5.md
@@ -2,7 +2,7 @@
 availability: 2
 classification: 4
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-03-05.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)

--- a/meta/3-4-1.md
+++ b/meta/3-4-1.md
@@ -2,7 +2,7 @@
 availability: null
 classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 72.6

--- a/meta/3-4-2.md
+++ b/meta/3-4-2.md
@@ -2,7 +2,7 @@
 availability: null
 classification: 2
 computation_units: на 100 000 населения
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 65.1

--- a/meta/3-5-1.md
+++ b/meta/3-5-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: "на\n 100 000 населения"
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: Министерство здравоохранения Республики Казахстан
 source_data_1: Административные данные
 source_implementation_1: Министерство здравоохранения Республики Казахстан
-tags:
-- meta.customisation-3
+tags: []
+
 target: Strengthen the prevention and treatment of substance abuse, including narcotic
   drug abuse and harmful use of alcohol
 target_id: '3.5'

--- a/meta/3-5-2.md
+++ b/meta/3-5-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: "3 уровень. \nОтложить на более поздний срок"
+classification: 3
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 214

--- a/meta/3-6-1.md
+++ b/meta/3-6-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: на 100 000 населения
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 213

--- a/meta/3-7-1.md
+++ b/meta/3-7-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-07-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)

--- a/meta/3-7-2.md
+++ b/meta/3-7-2.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: "на 1 000 женщин\n в данной возрастной группе"
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://data.un.org/Data.aspx?q=births&d=WDI&f=Indicator_Code%3aSP.ADO.TFRT
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 90.8

--- a/meta/3-8-1.md
+++ b/meta/3-8-1.md
@@ -1,9 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень. Методология на глобальном уровне есть. Привлечь ВОЗ для
-  расчета показателя
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)

--- a/meta/3-8-2.md
+++ b/meta/3-8-2.md
@@ -1,9 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень. Методология на глобальном уровне есть. Данные будут рассчитаны
-  с 2020 года
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/3-9-1.md
+++ b/meta/3-9-1.md
@@ -1,9 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень. Методология на глобальном уровне есть. Привлечь международного
-  эксперта для расчета. Данные будут рассчитаны с 2019 года
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 216

--- a/meta/3-9-2.md
+++ b/meta/3-9-2.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: "на 100 000\n населения"
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 214

--- a/meta/3-9-3.md
+++ b/meta/3-9-3.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: "на 100 000\n населения"
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-09-03.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 213

--- a/meta/3-b-1.md
+++ b/meta/3-b-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-3.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/3-b-2.md
+++ b/meta/3-b-2.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: млн.долларов США
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0B-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210

--- a/meta/3-b-3.md
+++ b/meta/3-b-3.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: null
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link_text: UN Metadata
 graph_title: meta.name-3-b-3
@@ -21,8 +21,8 @@ source_compilation_1: Комитет фармации Министерства �
 source_data_1: Административные  данные
 source_implementation_1: Комитет фармации Министерства здравоохранения Республики
   Казахстан
-tags:
-- meta.customisation-3
+tags: []
+
 target: Support the research and development of vaccines and medicines for the communicable
   and non‑communicable diseases that primarily affect developing countries, provide
   access to affordable essential medicines and vaccines, in accordance with the Doha

--- a/meta/3-c-1.md
+++ b/meta/3-c-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: на  1 000 населения
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0C-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 207
@@ -24,8 +24,8 @@ source_active_1: true
 source_compilation_1: Министерство здравоохранения Республики Казахстан
 source_data_1: Административные  данные
 source_implementation_1: Министерство здравоохранения Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: Substantially increase health financing and the recruitment, development,
   training and retention of the health workforce in developing countries, especially
   in least developed countries and small island developing States

--- a/meta/3-d-1.md
+++ b/meta/3-d-1.md
@@ -1,8 +1,8 @@
 ---
 availability: null
-classification: 3 уровень. Привлечь экспертов от ВОЗ для расчета. Данные отсутствуют
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-03-0D-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 865kB)

--- a/meta/4-1-1.md
+++ b/meta/4-1-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 1
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
@@ -22,8 +22,8 @@ source_active_1: true
 source_compilation_1: Министерство образования и науки Республики Казахстан
 source_data_1: Результаты PISA
 source_implementation_1: Министерство образования и науки Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, ensure that all girls and boys complete free, equitable and quality
   primary and secondary education leading to relevant and effective learning outcomes
 target_id: '4.1'

--- a/meta/4-2-1.md
+++ b/meta/4-2-1.md
@@ -2,7 +2,7 @@
 availability: null
 classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/4-2-2.md
+++ b/meta/4-2-2.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-04-02-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 223
@@ -22,8 +22,8 @@ source_active_1: true
 source_compilation_1: Министерство образования и науки Республики Казахстан
 source_data_1: "Административные\n данные (НОБД)"
 source_implementation_1: Министерство образования и науки Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, ensure that all girls and boys have access to quality early childhood
   development, care and pre-primary education so that they are ready for primary education
 target_id: '4.2'

--- a/meta/4-3-1.md
+++ b/meta/4-3-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-03-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
@@ -25,8 +25,8 @@ source_active_1: true
 source_compilation_1: Министерство образования и науки Республики Казахстан
 source_data_1: PIAAC 2017-2020
 source_implementation_1: Министерство образования и науки Республики Казахстан
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2030, ensure equal access for all women and men to affordable and quality
   technical, vocational and tertiary education, including university
 target_id: '4.3'

--- a/meta/4-4-1.md
+++ b/meta/4-4-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 214

--- a/meta/4-5-1.md
+++ b/meta/4-5-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 210kB)

--- a/meta/4-6-1.md
+++ b/meta/4-6-1.md
@@ -2,7 +2,7 @@
 availability: 2
 classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 57.8

--- a/meta/4-7-1.md
+++ b/meta/4-7-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-4.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 210kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МОН РК
 source_data_1: null
 source_implementation_1: МОН РК
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2030, ensure that all learners acquire the knowledge and skills needed
   to promote sustainable development, including, among others, through education for
   sustainable development and sustainable lifestyles, human rights, gender equality,

--- a/meta/4-a-1.md
+++ b/meta/4-a-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-04-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 210kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: Министерство образования и науки Республики Казахстан
 source_data_1: Административные данные (НОБД)
 source_implementation_1: Министерство образования и науки Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: Build and upgrade education facilities that are child, disability and gender
   sensitive and provide safe, non-violent, inclusive and effective learning environments
   for all

--- a/meta/4-c-1.md
+++ b/meta/4-c-1.md
@@ -2,7 +2,7 @@
 availability: null
 classification: 2
 computation_units: null
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-04-0C-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 218
@@ -23,8 +23,8 @@ source_compilation_1: Министерство образования и нау�
 source_data_1: Административные данные
 source_implementation_1: Министерство образования и науки Республики Казахстан, Министерство
   национальной экономики Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, substantially increase the supply of qualified teachers, including
   through international cooperation for teacher training in developing countries,
   especially least developed countries and small island developing States

--- a/meta/5-1-1.md
+++ b/meta/5-1-1.md
@@ -2,7 +2,7 @@
 availability: 2
 classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)

--- a/meta/5-2-1.md
+++ b/meta/5-2-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 518
@@ -27,8 +27,8 @@ source_compilation_1: Комитет по статистике Министер�
 source_data_1: Выборочное обследование по насилию в отношении женщин
 source_implementation_1: Министерство внутренних дел РК, Министерство труда и социальной
   защиты РК, Министерство образования и науки РК, МЗ РК, МИОР РК
-tags:
-- meta.customisation-2
+tags: []
+
 target: Eliminate all forms of violence against all women and girls in the public
   and private spheres, including trafficking and sexual and other types of exploitation
 target_id: '5.2'

--- a/meta/5-2-2.md
+++ b/meta/5-2-2.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 294
@@ -27,8 +27,8 @@ source_compilation_1: Комитет по статистике Министер�
 source_data_1: Выборочное обследование по насилию в отношении женщин
 source_implementation_1: Министерство внутренних дел РК, Министерство труда и социальной
   защиты РК, Министерство образования и науки РК, МЗ Рк, МИОР
-tags:
-- meta.customisation-2
+tags: []
+
 target: Eliminate all forms of violence against all women and girls in the public
   and private spheres, including trafficking and sexual and other types of exploitation
 target_id: '5.2'

--- a/meta/5-3-1.md
+++ b/meta/5-3-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 207
   KB)

--- a/meta/5-3-2.md
+++ b/meta/5-3-2.md
@@ -2,7 +2,7 @@
 availability: 2
 classification: 4
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-03-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 206

--- a/meta/5-4-1.md
+++ b/meta/5-4-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-04-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 337

--- a/meta/5-5-1.md
+++ b/meta/5-5-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/5-5-2.md
+++ b/meta/5-5-2.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 372

--- a/meta/5-6-1.md
+++ b/meta/5-6-1.md
@@ -2,7 +2,7 @@
 availability: 2
 classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)

--- a/meta/5-6-2.md
+++ b/meta/5-6-2.md
@@ -2,7 +2,7 @@
 availability: 2
 classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)

--- a/meta/5-a-1.md
+++ b/meta/5-a-1.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: человек
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
@@ -25,8 +25,8 @@ source_data_1: Ведомственные данные Республики Ка
   органы ведомственные данные
 source_implementation_1: Комитет по управлению земельными ресурсами Министерство сельского
   хозяйства Республики
-tags:
-- meta.customisation-2
+tags: []
+
 target: Undertake reforms to give women equal rights to economic resources, as well
   as access to ownership and control over land and other forms of property, financial
   services, inheritance and natural resources, in accordance with national laws

--- a/meta/5-a-2.md
+++ b/meta/5-a-2.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 4
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)

--- a/meta/5-b-1.md
+++ b/meta/5-b-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-05-0B-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 211
@@ -23,8 +23,8 @@ source_compilation_1: Комитет по статистике (Управлен
   Министерство национальной экономики Республики Казахстан
 source_data_1: Выборочное обследование по использованию ИКТ домашними хозяйствами
 source_implementation_1: Министерство информации и коммуникаций Республики Казахстан
-tags:
-- meta.customisation-3
+tags: []
+
 target: Enhance the use of enabling technology, in particular information and communications
   technology, to promote the empowerment of women
 target_id: 5.b

--- a/meta/5-c-1.md
+++ b/meta/5-c-1.md
@@ -1,10 +1,8 @@
 ---
 availability: 2
-classification: '3 уровень
-
-  Данные отсутствуют (не внедрена система гендернего бюджетирования)'
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-5.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 634kB)

--- a/meta/6-1-1.md
+++ b/meta/6-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-01-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МИИР РК (ЖКХ)
 source_data_1: null
 source_implementation_1: МИИР РК (ЖКХ)
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, achieve universal and equitable access to safe and affordable drinking
   water for all
 target_id: '6.1'

--- a/meta/6-2-1.md
+++ b/meta/6-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МИИР РК (ЖКХ)
 source_data_1: null
 source_implementation_1: МИИР РК (ЖКХ)
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2030, achieve access to adequate and equitable sanitation and hygiene for
   all and end open defecation, paying special attention to the needs of women and
   girls and those in vulnerable situations

--- a/meta/6-3-1.md
+++ b/meta/6-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)
@@ -22,8 +22,8 @@ source_compilation_1: Комитет по статистике Министер�
   Казахстан (Управление статистики производства и окружающей среды)
 source_data_1: Статистическая форма 1-ВК
 source_implementation_1: МСХ, МИИР (КДС)
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, improve water quality by reducing pollution, eliminating dumping
   and minimizing release of hazardous chemicals and materials, halving the proportion
   of untreated wastewater and substantially increasing recycling and safe reuse globally

--- a/meta/6-3-2.md
+++ b/meta/6-3-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
@@ -27,8 +27,8 @@ source_compilation_1: МЭ (Казгидромет-поверхностные), 
   МЗ (КООЗ-культурно бытовые)
 source_data_1: null
 source_implementation_1: "МСХ, МИИР (КГН), \nМЗ (КООЗ)"
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, improve water quality by reducing pollution, eliminating dumping
   and minimizing release of hazardous chemicals and materials, halving the proportion
   of untreated wastewater and substantially increasing recycling and safe reuse globally

--- a/meta/6-4-1.md
+++ b/meta/6-4-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)

--- a/meta/6-4-2.md
+++ b/meta/6-4-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)

--- a/meta/6-5-1.md
+++ b/meta/6-5-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-06-05-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 410

--- a/meta/6-5-2.md
+++ b/meta/6-5-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/6-6-1.md
+++ b/meta/6-6-1.md
@@ -1,8 +1,8 @@
 ---
 availability: null
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-6.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 428kB)

--- a/meta/6-a-1.md
+++ b/meta/6-a-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-06-0A-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 398

--- a/meta/7-1-1.md
+++ b/meta/7-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 212
   KB)
@@ -22,8 +22,8 @@ source_compilation_1: Комитет по статистике  (Управле�
   и классификаций) Министерства национальной экономики Республики Казахстан
 source_data_1: Информационная система "Статистический регистр жилищного фонда"
 source_implementation_1: Министерство энергетики Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, ensure universal access to affordable, reliable and modern energy
   services
 target_id: '7.1'

--- a/meta/7-1-2.md
+++ b/meta/7-1-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 4
+customisation: meta.customisation-4
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-07-01-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 232
@@ -29,8 +29,8 @@ source_active_1: true
 source_compilation_1: МЭ РК
 source_data_1: null
 source_implementation_1: МЭ РК
-tags:
-- meta.customisation-4
+tags: []
+
 target: By 2030, ensure universal access to affordable, reliable and modern energy
   services
 target_id: '7.1'

--- a/meta/7-2-1.md
+++ b/meta/7-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-07-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 216
@@ -25,8 +25,8 @@ source_data_1: 'Отчет "Топливно-энергетический бал
 
   1-ТЭБ'
 source_implementation_1: Министерство энергетики Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, increase substantially the share of renewable energy in the global
   energy mix
 target_id: '7.2'

--- a/meta/7-3-1.md
+++ b/meta/7-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: тнэ на тыс.долл. США в ценах  2010 года
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-07-03-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 192
@@ -24,8 +24,8 @@ source_compilation_1: Комитет по статистике (Управлен
 source_data_1: "Отчет \"Топливно-энергетический баланс\" \n1-ТЭБ"
 source_implementation_1: Министерство индустрии и инфраструктурного развития Республики
   Казахстан, Министерство энергетики Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, double the global rate of improvement in energy efficiency
 target_id: '7.3'
 un_custodian_agency: International Energy Agency (IEA) United Nations Statistics Division

--- a/meta/7-a-1.md
+++ b/meta/7-a-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-7.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 111

--- a/meta/7-b-1.md
+++ b/meta/7-b-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: тыс.тенге
-customisation: 4
+customisation: meta.customisation-4
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-7.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0
@@ -24,8 +24,8 @@ source_compilation_1: Комитет по статистике Министер�
 source_data_1: форма 1-инвест "Отчет об инвестициях в основной капитал"
 source_implementation_1: "Министерство национальной экономики Республики Казахстан,\
   \ \nМИД РК"
-tags:
-- meta.customisation-4
+tags: []
+
 target: By 2030, expand infrastructure and upgrade technology for supplying modern
   and sustainable energy services for all in developing countries, in particular least
   developed countries, small island developing States and landlocked developing countries,

--- a/meta/8-1-1.md
+++ b/meta/8-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: "в процентах к \n2005 году"
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-01-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 232

--- a/meta/8-10-1.md
+++ b/meta/8-10-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-10-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)

--- a/meta/8-10-2.md
+++ b/meta/8-10-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 210
   KB)

--- a/meta/8-2-1.md
+++ b/meta/8-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: "в процентах к \nпредыдущему году"
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-02-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 384

--- a/meta/8-4-1.md
+++ b/meta/8-4-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/8-4-2.md
+++ b/meta/8-4-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3  уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-04-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 58.7

--- a/meta/8-5-1.md
+++ b/meta/8-5-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: тенге
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 317
@@ -24,8 +24,8 @@ source_compilation_1: Комитет по статистике Министер�
 source_data_1: Выборочное обследование предприятий
 source_implementation_1: Министерство труда и социальной защиты населения Республики
   Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: 8.5 By 2030, achieve full and productive employment and decent work for all
   women and men, including for young people and persons with disabilities, and equal
   pay for work of equal value

--- a/meta/8-5-2.md
+++ b/meta/8-5-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-08-05-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 383

--- a/meta/8-6-1.md
+++ b/meta/8-6-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-06-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 382

--- a/meta/8-7-1.md
+++ b/meta/8-7-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-07-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)
@@ -24,8 +24,8 @@ source_data_1: Выборочное обследование  занятости
 source_implementation_1: Министерство труда и социальной защиты населения Республики
   Казахстан, Министерство образования и науки Республики Казахстан,  Министерство
   по делам религий и гражданского общества Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: Take immediate and effective measures to eradicate forced labour, end modern
   slavery and human trafficking and secure the prohibition and elimination of the
   worst forms of child labour, including recruitment and use of child soldiers, and

--- a/meta/8-8-1.md
+++ b/meta/8-8-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: коэффициент частоты несчастных случаев на 1000 человек
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-08-08-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 381
@@ -22,8 +22,8 @@ source_active_1: true
 source_compilation_1: МТСЗН РК, МИО
 source_data_1: null
 source_implementation_1: МТСЗН РК
-tags:
-- meta.customisation-2
+tags: []
+
 target: Protect labour rights and promote safe and secure working environments for
   all workers, including migrant workers, in particular women migrants, and those
   in precarious employment

--- a/meta/8-8-2.md
+++ b/meta/8-8-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процентах
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)
@@ -21,8 +21,8 @@ source_active_1: true
 source_compilation_1: МТСЗН РК, МИО
 source_data_1: null
 source_implementation_1: МТСЗН РК
-tags:
-- meta.customisation-3
+tags: []
+
 target: ' Protect labour rights and promote safe and secure working environments for
   all workers, including migrant workers, in particular women migrants, and those
   in precarious employment'

--- a/meta/8-9-1.md
+++ b/meta/8-9-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 526
@@ -25,8 +25,8 @@ source_compilation_1: Комитет по статистике Министер�
   Казахстан  (Управление национальных счетов)
 source_data_1: "Бюллетень \n\"Вспомогательный счет туризма\""
 source_implementation_1: Министерство культуры и спорта Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, devise and implement policies to promote sustainable tourism that
   creates jobs and promotes local culture and products
 target_id: '8.9'

--- a/meta/8-9-2.md
+++ b/meta/8-9-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 526
@@ -25,8 +25,8 @@ source_compilation_1: Комитет по статистике  Министер
 source_data_1: "Бюллетень \n\"Вспомогательный счет туризма\""
 source_implementation_1: Министерство культуры и спорта Республики Казахстан, Министерство
   труда и социальной защиты Республики Казахстан
-tags:
-- meta.customisation-2
+tags: []
+
 target: By 2030, devise and implement policies to promote sustainable tourism that
   creates jobs and promotes local culture and products
 target_id: '8.9'

--- a/meta/8-b-1.md
+++ b/meta/8-b-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 3
+customisation: meta.customisation-3
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-8.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 525kB)
@@ -23,8 +23,8 @@ source_compilation_1: Министерство труда и социально�
 source_data_1: null
 source_implementation_1: Министерство труда и социальной защиты населения Республики
   Казахстан, МИОР РК
-tags:
-- meta.customisation-3
+tags: []
+
 target: By 2020, develop and operationalize a global strategy for youth employment
   and implement the Global Jobs Pact of the International Labour Organization
 target_id: 8.b

--- a/meta/9-1-1.md
+++ b/meta/9-1-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-9.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 663kB)

--- a/meta/9-1-2.md
+++ b/meta/9-1-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: млн.тонн
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-01-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 375

--- a/meta/9-2-1.md
+++ b/meta/9-2-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: процент, в ценах 2010 года
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-02-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 217

--- a/meta/9-2-2.md
+++ b/meta/9-2-2.md
@@ -2,7 +2,7 @@
 availability: 1
 classification: 2
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-02-02.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 323

--- a/meta/9-3-1.md
+++ b/meta/9-3-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 1 уровень
+classification: 1
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-9.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 4.0

--- a/meta/9-3-2.md
+++ b/meta/9-3-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 2
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: http://unstats.un.org/sdgs/files/metadata-compilation/Metadata-Goal-9.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (pdf 663kB)

--- a/meta/9-4-1.md
+++ b/meta/9-4-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 3 уровень
+classification: 3
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-04-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 516

--- a/meta/9-5-1.md
+++ b/meta/9-5-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-05-01.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 382
@@ -25,8 +25,8 @@ source_data_1: Отчет о научно-исследовательских и 
 source_implementation_1: Министерство образования и науки Республики Казахстан (Комитет
   по науке), Министерство по инвестициям и развитию Республики Казахстан, Все отраслевые
   государственные органы
-tags:
-- meta.customisation-2
+tags: []
+
 target: Enhance scientific research, upgrade the technological capabilities of industrial
   sectors in all countries, in particular developing countries, including, by 2030,
   encouraging innovation and substantially increasing the number of research and development

--- a/meta/9-5-2.md
+++ b/meta/9-5-2.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: человек
-customisation: 2
+customisation: meta.customisation-2
 data_non_statistical: false
 goal_meta_link: https://unstats.un.org/sdgs/metadata/files/Metadata-09-05-02.pdf
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 382
@@ -25,8 +25,8 @@ source_data_1: Отчет о научно-исследовательских и 
 source_implementation_1: Министерство образования и науки Республики Казахстан (Комитет
   по науке), Министерство по инвестициям и развитию Республики Казахстан, Все отраслевые
   государственные органы
-tags:
-- meta.customisation-2
+tags: []
+
 target: Enhance scientific research, upgrade the technological capabilities of industrial
   sectors in all countries, in particular developing countries, including, by 2030,
   encouraging innovation and substantially increasing the number of research and development

--- a/meta/9-a-1.md
+++ b/meta/9-a-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 2 уровень
+classification: 2
 computation_units: null
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-0A-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 208

--- a/meta/9-b-1.md
+++ b/meta/9-b-1.md
@@ -1,8 +1,8 @@
 ---
 availability: 1
-classification: 1 уровень
+classification: 1
 computation_units: процент
-customisation: 1
+customisation: meta.customisation-1
 data_non_statistical: false
 goal_meta_link: 'https://unstats.un.org/sdgs/metadata/files/Metadata-09-0B-01.pdf '
 goal_meta_link_text: United Nations Sustainable Development Goals Metadata (PDF 332


### PR DESCRIPTION
This removes the "tags" and adds the value to the "Customisation" field, so that it will show up in "National Metadata" instead of on goal pages as tags.