### PR TITLE
Upgrade to SDMX 2.3.0

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,4 +4,3 @@ git+git://github.com/brockfanning/sdg-build-1@kazakhstan-feature-set
 xlrd
 python-frontmatter
 sdmx1==2.3.0
-pydantic==1.7.3

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,5 +3,5 @@ git+git://github.com/dougmet/yamlmd
 git+git://github.com/brockfanning/sdg-build-1@kazakhstan-feature-set
 xlrd
 python-frontmatter
-sdmx1==2.2.1
+sdmx1==2.3.0
 pydantic==1.7.3


### PR DESCRIPTION
This will change the SDMX format to "StructureSpecific", which is the preferred format at the UN.